### PR TITLE
chore(ts): enable @/* alias and Next TS plugin

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,22 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
- Updated tsconfig.json to enable @/* path alias for cleaner imports.
- Added Next.js TypeScript plugin.
- Extended include paths to cover .next/types.

This improves developer experience and prepares the codebase for cleaner, consistent imports.

## Summary
- add `baseUrl` and `@/*` path alias so TypeScript resolves project modules

## Testing
- `npx tsc --noEmit --incremental false`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68adb83eae848320a74cb0ac6db0d7e3