### PR TITLE
chore(ts,docs): enable @/* alias and add architecture guide

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,31 @@
-# Architecture
+# Global Alignment Index — Codebase Overview
 
-- Use @/... alias for imports instead of relative paths.
+This repo powers the **Global Alignment Index (GAI)**, a factual, opinion-free dashboard that tracks whether humanity is becoming more aligned — or less — over time.
+
+## Folder Structure
+
+- **app/** — Next.js App Router
+  - `layout.tsx`: metadata + global layout.
+  - `page.tsx`: homepage, loads JSON from `/public/data`, computes z-scores, renders charts (Recharts).
+- **lib/** — helpers
+  - `metrics.ts`: registry of metrics (id, name, domain, unit, ↑/↓ better, source).
+- **public/data/** — JSON time series per metric (e.g., `co2_ppm.json`, `life_expectancy.json`).
+- **docs/** — trust & context
+  - `METHODS.md`: aggregation rules and sources.
+  - `CHANGELOG.md`: every change logged.
+  - `GAI_CONTEXT.md`: mission and scope of the project.
+  - `ARCHITECTURE.md`: (this file) overview for newcomers.
+
+## Key Concepts
+
+- **Factual metrics only**: each metric is direction-clear (↑ better or ↓ better).
+- **Aggregation (v0.1)**: per-metric z-scores → per-year average for the index (see `docs/METHODS.md`).
+- **Tech stack**: Next.js + React, TypeScript, TailwindCSS, Recharts.
+- **CI/CD**: GitHub Actions + Vercel → every PR gets a Preview URL; `main` → Production.
+
+## Imports & Paths
+
+- Use the root alias **`@/…`** for imports instead of relative paths.  
+  Example:
+  ```ts
+  import { METRICS } from '@/lib/metrics'


### PR DESCRIPTION
What
- Enable @/* path alias in tsconfig.json and add Next.js TS plugin; include .next/types.
- Add beginner-friendly docs/ARCHITECTURE.md (repo structure, key files, imports & paths, first steps).
- Add CHANGELOG entry for alias usage (2025-08-27).

Why
- Cleaner imports and better developer experience.
- Clearer onboarding for new contributors; aligns with our trust rails (METHODS, CHANGELOG).

Acceptance Criteria
- CI (typecheck/build) green.
- Vercel Preview green and homepage renders.
- docs/ARCHITECTURE.md present and readable; at least one import uses @/*.


## Summary
- refresh the architecture overview for newcomers in `docs/ARCHITECTURE.md`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68aedb1fcf388320b2886f82caba8f98