### PR TITLE
feat: add Coming Soon gate (public on Production, unlocked by key/cookie; Preview never blocked)

### DIFF
--- a/app/api/preview/route.ts
+++ b/app/api/preview/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const redirectTo = url.searchParams.get('to') || '/'
+  const res = NextResponse.redirect(new URL(redirectTo, url.origin))
+  res.cookies.set('preview', '1', { httpOnly: true, path: '/', maxAge: 60 * 60 * 24 })
+  return res
+}

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -1,0 +1,15 @@
+export default function ComingSoon() {
+  return (
+    <main className="min-h-screen grid place-items-center p-8">
+      <div className="max-w-xl text-center space-y-4">
+        <h1 className="text-3xl font-semibold">Global Alignment Index</h1>
+        <p className="opacity-70">
+          We’re tuning the instruments. A first public version is coming soon.
+        </p>
+        <p className="text-sm opacity-60">
+          Collaborators: append <code>?key=opensesame</code> or visit <code>/api/preview</code> to view.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const PUBLIC_PATHS = [
+  '/coming-soon',
+  '/favicon',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/assets',
+  '/api/preview',
+  '/_next', // Next.js internals and static assets
+]
+
+export function middleware(req: NextRequest) {
+  const url = req.nextUrl
+  const { pathname, searchParams, hostname } = url
+
+  // Always allow internal/static/public routes
+  if (PUBLIC_PATHS.some(p => pathname === p || pathname.startsWith(p))) {
+    return NextResponse.next()
+  }
+
+  // Allow all Vercel Preview deployments to bypass the gate
+  if (process.env.VERCEL_ENV === 'preview' || hostname.endsWith('.vercel.app')) {
+    return NextResponse.next()
+  }
+
+  // One-time key unlock via query param (?key=...)
+  const expected = process.env.NEXT_PUBLIC_PREVIEW_KEY || 'opensesame'
+  const provided = searchParams.get('key')
+  if (provided && provided === expected) {
+    const res = NextResponse.redirect(new URL(pathname, url.origin))
+    res.cookies.set('preview', '1', { httpOnly: true, path: '/', maxAge: 60 * 60 * 24 })
+    return res
+  }
+
+  // Cookie unlock after /api/preview or key flow
+  const hasPreviewCookie = req.cookies.get('preview')?.value === '1'
+  if (hasPreviewCookie) {
+    return NextResponse.next()
+  }
+
+  // Default: show Coming Soon on Production
+  const rewrite = url.clone()
+  rewrite.pathname = '/coming-soon'
+  rewrite.search = ''
+  return NextResponse.rewrite(rewrite)
+}


### PR DESCRIPTION
## Summary
- add Coming Soon page with collaborator access hint
- add preview API route that sets unlock cookie
- introduce middleware to gate production but always allow preview deployments or unlocked sessions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires configuration setup)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af08a084e08320a262813ecb3a3b52
##
What
- Added app/coming-soon/page.tsx (public Coming Soon notice).
- Added app/api/preview/route.ts to set a 'preview=1' cookie for collaborators.
- Added middleware.ts to rewrite public Production traffic to /coming-soon, with:
  - Full bypass on Vercel Preview deployments,
  - One-time key unlock via ?key=NEXT_PUBLIC_PREVIEW_KEY (fallback 'opensesame'),
  - Cookie unlock after /api/preview or key.

Why
- Keep domain public and clean while we build.
- Ensure collaborators can view the live app (Preview URLs, key/cookie unlock).
- Zero DNS juggling; single project flow.

Acceptance Criteria
- Vercel Preview is accessible (no gate).
- On Production, public visitors see /coming-soon.
- Unlock works via:
  - https://<prod-domain>/?key=<key>  (sets cookie, removes query)
  - https://<prod-domain>/api/preview  (sets cookie)
- CI build passes; Vercel Preview is green.