### PR TITLE
chore(ui): soften background, tighten typography, add subtle card shadow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0b0d10;
+  --bg: #0d1117;
   --fg: #e8eef6;
   --muted: #9fb0c0;
   --card: #12161b;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen antialiased">{children}</body>
+      <body className="min-h-screen antialiased">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+          {children}
+        </div>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,14 +44,14 @@ export default function Home() {
 
   return (
     <main className="mx-auto max-w-6xl p-6 space-y-8">
-      <header className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-semibold">Global Alignment Index <span className="text-sm opacity-70">v0.1</span></h1>
-          <p className="opacity-70">Factual signals; no opinions. A simple aggregate line + domain charts (mock data for now).</p>
-        </div>
-      </header>
+        <header className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight">Global Alignment Index <span className="text-sm opacity-70">v0.1</span></h1>
+            <p className="opacity-70">Factual signals; no opinions. A simple aggregate line + domain charts (mock data for now).</p>
+          </div>
+        </header>
 
-      <section className="card p-4">
+      <section className="card p-4 shadow-sm">
         <h2 className="text-xl mb-2">Whole Alignment Trend (aggregate, mock)</h2>
         <div className="w-full h-64">
           <ResponsiveContainer width="100%" height="100%">
@@ -69,7 +69,7 @@ export default function Home() {
 
       <section className="grid md:grid-cols-2 gap-6">
         {Object.keys(data).map((k, i) => (
-          <div key={k} className="card p-4">
+          <div key={k} className="card p-4 shadow-sm">
             <h3 className="text-lg font-medium">{METRICS.find(m=>m.id===k)?.name}</h3>
             <div className="w-full h-56 mt-2">
               <ResponsiveContainer width="100%" height="100%">


### PR DESCRIPTION
## Summary
- soften global background color to a calmer slate
- add responsive container padding and typography for layout
- tighten heading tracking and add subtle card shadows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68af3cb953008320a8f98045740ea36f

##
What
- Calmer background (#0d1117) for global canvas.
- Centered content container for readability (max-w-6xl + responsive padding).
- Crisper h1 (tracking-tight) + subtle shadows on cards.

Why
- Improves readability and visual hierarchy without changing logic.
- Keeps Tailwind classes visible alongside JSX for transparent styling.

Acceptance
- CI (typecheck/build) green.
- Vercel Preview renders with updated styling.
- Production gate unchanged; /api/preview still unlocks the app.