### PR TITLE
chore(ui): add Preview badge visible only on Preview deployments

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import PreviewBadge from '@/components/PreviewBadge'
 
 export const metadata: Metadata = {
   title: 'Global Alignment Index — v0.1',
@@ -12,6 +13,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           {children}
         </div>
+        <PreviewBadge />
       </body>
     </html>
   )

--- a/components/PreviewBadge.tsx
+++ b/components/PreviewBadge.tsx
@@ -1,0 +1,25 @@
+'use client'
+export default function PreviewBadge() {
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview') return null
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 12,
+        right: 12,
+        zIndex: 50,
+        background: 'rgba(0,0,0,0.6)',
+        color: 'white',
+        borderRadius: 8,
+        padding: '6px 10px',
+        fontSize: 12,
+        letterSpacing: 0.2,
+        backdropFilter: 'blur(4px)',
+      }}
+      aria-label="Preview build"
+      title="This is a Vercel Preview deployment"
+    >
+      Preview
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add PreviewBadge client component rendering only when `NEXT_PUBLIC_VERCEL_ENV` equals `preview`
- Display PreviewBadge in `app/layout.tsx` after the main container

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af4f99dabc832092b175cb6a8fff19
------

What
- Added components/PreviewBadge.tsx to render a subtle "Preview" label in the top-right corner.
- Imported and rendered in app/layout.tsx after the main container.
- Controlled via NEXT_PUBLIC_VERCEL_ENV env var:
  - Renders only when NEXT_PUBLIC_VERCEL_ENV === 'preview'.
  - Hidden in production.

Why
- Helps collaborators and reviewers instantly recognize Preview builds.
- Reduces confusion between Preview URLs and Production domain.

Acceptance Criteria
- CI build and typecheck pass.
- Vercel PR Preview shows "Preview" badge when env is set to preview.
- Production remains unchanged (no badge).