### PR TITLE
chore(data): add sources.json manifest; pipelines upsert metadata; render sources footer; add validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm install
       - run: npm run typecheck
       - run: npm run build
+      - run: npm run validate:sources

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts'
 import { METRICS } from '@/lib/metrics'
+import SourcesFooter from '@/components/SourcesFooter'
 
 type Pt = { year: number; value: number }
 function unitFor(id: string): string {
@@ -132,6 +133,7 @@ export default function Home() {
       <footer className="text-sm opacity-70 py-10">
         <p>Sources: NOAA, WHO, World Bank, ITU (real datasets to be wired). This is a v0.1 prototype.</p>
       </footer>
+      <SourcesFooter />
     </main>
   )
 }

--- a/components/SourcesFooter.tsx
+++ b/components/SourcesFooter.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type SourceMeta = {
+  name?: string
+  domain?: string
+  unit?: string
+  source_org?: string
+  source_url?: string
+  updated_at?: string
+}
+
+export default function SourcesFooter() {
+  const [sources, setSources] = useState<Record<string, SourceMeta>>({})
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/data/sources.json', { cache: 'no-store' })
+        if (!res.ok) return
+        const json = await res.json()
+        setSources(json)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    load()
+  }, [])
+
+  const entries = Object.entries(sources)
+  if (!entries.length) return null
+
+  return (
+    <section className="text-sm opacity-70 py-10">
+      <h2 className="text-base font-medium mb-2">Data Sources / Thanks</h2>
+      <ul className="space-y-1">
+        {entries.map(([id, s]) => (
+          <li key={id}>
+            <span className="font-medium">{s.name}</span>{' '}
+            {s.source_org && s.source_url ? (
+              <a className="underline" href={s.source_url} target="_blank" rel="noreferrer">
+                {s.source_org}
+              </a>
+            ) : (
+              s.source_org
+            )}
+            {s.unit && ` · ${s.unit}`}
+            {s.domain && ` · ${s.domain}`}
+            {s.updated_at && ` · updated ${s.updated_at}`}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "fetch:co2": "node --import=./scripts/register.mjs scripts/pipelines/co2.ts || node scripts/pipelines/co2.js",
-    "fetch:all": "node --import=./scripts/register.mjs scripts/fetch-all.ts || node scripts/fetch-all.js"
+    "fetch:all": "node --import=./scripts/register.mjs scripts/fetch-all.ts || node scripts/fetch-all.js",
+    "validate:sources": "node --import=./scripts/register.mjs scripts/validate-sources.ts || node scripts/validate-sources.js"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/public/data/sources.json
+++ b/public/data/sources.json
@@ -1,0 +1,29 @@
+{
+  "life_expectancy": {
+    "name": "Life expectancy",
+    "domain": "Health & Wellbeing",
+    "unit": "years",
+    "source_org": "World Bank",
+    "source_url": "https://data.worldbank.org/indicator/SP.DYN.LE00.IN",
+    "license": "CC BY 4.0"
+  },
+  "internet_use": {
+    "name": "Individuals using the internet",
+    "domain": "Education & Digital",
+    "unit": "%",
+    "source_org": "International Telecommunication Union",
+    "source_url": "https://data.worldbank.org/indicator/IT.NET.USER.ZS",
+    "license": "CC BY 4.0"
+  },
+  "co2_ppm": {
+    "name": "CO₂ (Global)",
+    "domain": "Climate & Environment",
+    "unit": "ppm",
+    "source_org": "NOAA Global Monitoring Laboratory",
+    "source_url": "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_mm_gl.csv",
+    "license": "Public domain / no known restrictions",
+    "method": "Annual mean of monthly averages, exclude -99.99; round to 2 decimals.",
+    "updated_at": "2025-08-27",
+    "data_start_year": 2000
+  }
+}

--- a/scripts/lib/manifest.ts
+++ b/scripts/lib/manifest.ts
@@ -1,0 +1,22 @@
+import { readFile, writeFile } from 'node:fs/promises'
+
+export async function readManifest(path: string = 'public/data/sources.json'): Promise<Record<string, any>> {
+  try {
+    const text = await readFile(path, 'utf8')
+    return JSON.parse(text)
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return {}
+    throw err
+  }
+}
+
+export async function writeManifest(manifest: Record<string, any>, path = 'public/data/sources.json'): Promise<void> {
+  const json = JSON.stringify(manifest, null, 2)
+  await writeFile(path, json)
+}
+
+export async function upsertSource(id: string, meta: Record<string, any>): Promise<void> {
+  const manifest = await readManifest()
+  manifest[id] = { ...(manifest[id] || {}), ...meta }
+  await writeManifest(manifest)
+}

--- a/scripts/pipelines/co2.ts
+++ b/scripts/pipelines/co2.ts
@@ -1,6 +1,7 @@
 import { parseCsv } from '../lib/csv.ts';
 import { makeAnnualMean } from '../lib/annualize.ts';
 import { writeJson } from '../lib/io.ts';
+import { upsertSource } from '../lib/manifest.ts';
 
 export async function run() {
   const res = await fetch('https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_mm_gl.csv');
@@ -9,6 +10,17 @@ export async function run() {
   const rows = parseCsv(text, { commentPrefix: '#'});
   const data = makeAnnualMean(rows, { yearCol: 0, valueCol: 3, missingValue: -99.99 });
   await writeJson('public/data/co2_ppm.json', data);
+  await upsertSource('co2_ppm', {
+    name: 'CO₂ (Global)',
+    domain: 'Climate & Environment',
+    unit: 'ppm',
+    source_org: 'NOAA Global Monitoring Laboratory',
+    source_url: 'https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_mm_gl.csv',
+    license: 'Public domain / no known restrictions',
+    method: 'Annual mean of monthly averages, exclude -99.99; round to 2 decimals.',
+    updated_at: new Date().toISOString().slice(0,10),
+    data_start_year: Array.isArray(data) && data.length ? data[0].year : undefined
+  })
   return data;
 }
 

--- a/scripts/validate-sources.ts
+++ b/scripts/validate-sources.ts
@@ -1,0 +1,25 @@
+import { METRICS } from '../lib/metrics.ts'
+import { readFile } from 'node:fs/promises'
+
+async function run() {
+  const ids = METRICS.map(m => m.id)
+  let manifest: Record<string, any> = {}
+  try {
+    const text = await readFile('public/data/sources.json', 'utf8')
+    manifest = JSON.parse(text)
+  } catch (err) {
+    console.error('Failed to read manifest')
+    process.exit(1)
+  }
+  const missing = ids.filter(id => !manifest[id])
+  if (missing.length) {
+    console.error('Missing manifest entries for:', missing.join(', '))
+    process.exit(1)
+  }
+  console.log('All metrics present in manifest')
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add manifest helper to read/write sources catalog
- upsert CO₂ metadata after pipeline run
- render data sources thanks footer on homepage
- validate manifest contains entries for all metrics in CI

## Testing
- `npm run fetch:co2` *(fails: fetch failed ENETUNREACH)*
- `npm run validate:sources`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af606fd77883209092a96308ea2192