### PR TITLE
chore(ui): show only active data sources (with updated_at) in footer

### DIFF
--- a/components/SourcesFooter.tsx
+++ b/components/SourcesFooter.tsx
@@ -19,8 +19,11 @@ export default function SourcesFooter() {
       try {
         const res = await fetch('/data/sources.json', { cache: 'no-store' })
         if (!res.ok) return
-        const json = await res.json()
-        setSources(json)
+        const json: Record<string, SourceMeta> = await res.json()
+        const filtered = Object.fromEntries(
+          Object.entries(json).filter(([, s]) => s.updated_at)
+        )
+        setSources(filtered)
       } catch (err) {
         console.error(err)
       }


### PR DESCRIPTION
## Summary
- filter sources loaded for footer to include only entries with an `updated_at` field

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b02498c7048320848323359e1ff63b
------

What
- Updated SourcesFooter.tsx to filter manifest entries by `updated_at`.
- Only sources with an updated_at (written by active pipelines) are shown.
- Placeholders without real pipelines (e.g. life_expectancy, internet_use) are hidden.

Why
- Prevents the footer from showing planned but inactive sources.
- Keeps “Data Sources / Thanks” aligned with datasets actually in use.
- Transparency: credits reflect live data only.

Acceptance
- Vercel Preview footer shows NOAA (CO₂) only.
- After adding new pipelines (e.g. life_expectancy), their sources appear automatically once updated_at is written.
- CI build/typecheck passes.