### PR TITLE
build(ci): use tsx to run TypeScript pipelines in Actions (fix fetch-all)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "fetch:co2": "node --import=./scripts/register.mjs scripts/pipelines/co2.ts || node scripts/pipelines/co2.js",
-    "fetch:all": "node --import=./scripts/register.mjs scripts/fetch-all.ts || node scripts/fetch-all.js",
+    "fetch:all": "tsx scripts/fetch-all.ts",
+    "fetch:co2": "tsx scripts/pipelines/co2.ts",
+    "fetch:life": "tsx scripts/pipelines/life_expectancy.ts",
+    "fetch:u5": "tsx scripts/pipelines/u5_mortality.ts",
     "validate:sources": "node scripts/validate-sources.js"
   },
   "dependencies": {
@@ -28,6 +30,7 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "eslint": "8.57.0",
-    "eslint-config-next": "14.2.5"
+    "eslint-config-next": "14.2.5",
+    "tsx": "^4.7.0"
   }
 }

--- a/scripts/register.mjs
+++ b/scripts/register.mjs
@@ -1,2 +1,0 @@
-import 'node:module';
-import 'node:fs';


### PR DESCRIPTION
## Summary
- run TypeScript scripts with tsx
- clean up legacy register.mjs helper

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b3987fd48320bc9f4fb246442eb6
------

What
- Add dev dependency "tsx" and run `fetch-all` via `tsx scripts/fetch-all.ts`.
- Remove obsolete Node ESM import fallback (--import=./scripts/register.mjs).
- No changes to pipeline code; just enable the Action to execute .ts files.

Why
- GitHub runner failed with ERR_UNKNOWN_FILE_EXTENSION when executing TypeScript scripts.
- tsx is a minimal, dev-only runner that lets Actions execute .ts directly.

Acceptance
- CI green.
- After merge: GitHub → Actions → Fetch Data → Run workflow on main:
  - The job should run `npm run fetch:all` successfully and open an auto PR with updated files under /public/data/** (and docs if touched).