### PR TITLE
fix(u5/ci): robust WDI pagination + logs; fail fetch-all on empty; add dataset sizes in workflow

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -25,15 +25,20 @@ jobs:
       - run: npm install
       - run: npm run fetch:all
 
+      - name: Show dataset sizes
+        run: |
+          ls -lh public/data | sed -n '1,200p'
+          node -e "const fs=require('fs');const f='public/data/u5_mortality.json'; console.log('u5 file size:', fs.existsSync(f)?fs.statSync(f).size:'missing')"
+
       # Fail if any dataset is empty []
       - name: Validate datasets not empty
         run: |
           node -e "
-          const fs=require('fs'),p='./public/data';
-          const files=fs.readdirSync(p).filter(f=>f.endsWith('.json')&&!['sources.json','metrics_registry.json'].includes(f));
-          let bad=[]; for (const f of files){const a=JSON.parse(fs.readFileSync(p+'/'+f,'utf8')||'[]'); if(Array.isArray(a)&&a.length===0) bad.push(f)}
-          if (bad.length){console.error('Empty datasets:', bad.join(', ')); process.exit(1)}
-          "
+            const fs=require('fs'),p='./public/data';
+            const files=fs.readdirSync(p).filter(f=>f.endsWith('.json')&&!['sources.json','metrics_registry.json'].includes(f));
+            let bad=[]; for (const f of files){const a=JSON.parse(fs.readFileSync(p+'/'+f,'utf8')||'[]'); if(Array.isArray(a)&&a.length===0) bad.push(f)}
+            if (bad.length){console.error('Empty datasets:', bad.join(', ')); process.exit(1)}
+            "
 
       - name: Create PR with changes
         uses: peter-evans/create-pull-request@v6

--- a/scripts/fetch-all.ts
+++ b/scripts/fetch-all.ts
@@ -11,6 +11,9 @@ export async function runAll() {
   for (const p of pipelines) {
     console.log(`start ${p.name}`);
     const data = await p.run();
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error(`pipeline ${p.name} returned empty data`);
+    }
     console.log(`done ${p.name} (${data.length})`);
   }
 }

--- a/scripts/pipelines/u5_mortality.ts
+++ b/scripts/pipelines/u5_mortality.ts
@@ -1,7 +1,6 @@
 import { writeJson } from '../lib/io.ts';
 import { upsertSource } from '../lib/manifest.ts';
 
-const WB_API = 'https://api.worldbank.org/v2';
 const INDICATOR = 'SH.DYN.MORT';
 const POP = 'SP.POP.TOTL';
 const EXCLUDE = new Set([
@@ -12,20 +11,28 @@ function isIso3(code: string): boolean {
   return /^[A-Z]{3}$/.test(code) && !EXCLUDE.has(code);
 }
 
-async function fetchIndicator(indicator: string) {
-  const url = `${WB_API}/country/all/indicator/${indicator}?format=json&per_page=20000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
-  const json = await res.json();
-  const rows = Array.isArray(json) ? json[1] : [];
-  return Array.isArray(rows) ? rows : [];
+async function fetchWdiAll(ind: string) {
+  const base =
+    'https://api.worldbank.org/v2/country/all/indicator/' +
+    ind +
+    '?format=json&per_page=20000';
+  const first = await (await fetch(base + '&page=1')).json();
+  const pages = (Array.isArray(first) && (first[0] as any)?.pages) || 1;
+  const rows = Array.isArray(first) && Array.isArray(first[1]) ? [...first[1]] : [];
+  for (let p = 2; p <= pages; p++) {
+    const part = await (await fetch(base + '&page=' + p)).json();
+    if (Array.isArray(part) && Array.isArray(part[1])) rows.push(...part[1]);
+  }
+  return rows;
 }
 
 export async function run() {
   const [mortRows, popRows] = await Promise.all([
-    fetchIndicator(INDICATOR),
-    fetchIndicator(POP),
+    fetchWdiAll(INDICATOR),
+    fetchWdiAll(POP),
   ]);
+  console.log('[u5] raw U5MR rows:', mortRows.length);
+  console.log('[u5] raw POP rows:', popRows.length);
 
   const mort: Record<string, Record<number, number>> = {};
   for (const d of mortRows) {
@@ -36,6 +43,7 @@ export async function run() {
     mort[iso] ??= {};
     mort[iso][year] = val;
   }
+  console.log('[u5] ISO3 with U5MR:', Object.keys(mort).length);
 
   const pop: Record<string, Record<number, number>> = {};
   for (const d of popRows) {
@@ -46,26 +54,32 @@ export async function run() {
     pop[iso] ??= {};
     pop[iso][year] = val;
   }
+  console.log('[u5] ISO3 with POP:', Object.keys(pop).length);
 
   const years = new Set<number>();
   for (const iso in mort) for (const y in mort[iso]) years.add(Number(y));
+  console.log('[u5] years count:', years.size);
 
-  const data = Array.from(years).map((year) => {
-    let totalPop = 0;
-    let weighted = 0;
-    for (const iso in mort) {
-      const u = mort[iso][year];
-      const p = pop[iso]?.[year];
-      if (u != null && p != null && !isNaN(u) && !isNaN(p)) {
-        weighted += u * p;
-        totalPop += p;
+  const data = Array.from(years)
+    .map((year) => {
+      let totalPop = 0;
+      let weighted = 0;
+      for (const iso in mort) {
+        const u = mort[iso][year];
+        const p = pop[iso]?.[year];
+        if (u != null && p != null && !isNaN(u) && !isNaN(p)) {
+          weighted += u * p;
+          totalPop += p;
+        }
       }
-    }
-    if (totalPop > 0) {
-      return { year, value: Math.round((weighted / totalPop) * 100) / 100 };
-    }
-    return undefined;
-  }).filter(Boolean).sort((a: any, b: any) => a.year - b.year) as {year:number, value:number}[];
+      if (totalPop > 0) {
+        return { year, value: Math.round((weighted / totalPop) * 100) / 100 };
+      }
+      return undefined;
+    })
+    .filter(Boolean)
+    .sort((a: any, b: any) => a.year - b.year) as { year: number; value: number }[];
+  console.log('[u5] computed points:', data.length);
   if (!Array.isArray(data) || data.length === 0) {
     throw new Error('u5_mortality: no data fetched — skipping write');
   }
@@ -79,8 +93,9 @@ export async function run() {
     source_url: 'https://data.worldbank.org/indicator/SH.DYN.MORT',
     license: 'CC BY 4.0',
     cadence: 'annual',
-    method: 'Population-weighted global mean of national SH.DYN.MORT using SP.POP.TOTL; exclude aggregates; round 2 decimals.',
-    updated_at: new Date().toISOString().slice(0,10),
+    method:
+      'Population-weighted global mean of national SH.DYN.MORT using SP.POP.TOTL; exclude aggregates; round 2 decimals.',
+    updated_at: new Date().toISOString().slice(0, 10),
     data_start_year: Array.isArray(data) && data.length ? data[0].year : undefined,
   });
   return data;


### PR DESCRIPTION
## Summary
- add helper to fetch all WDI pages for u5 mortality and log counts
- make fetch-all fail fast when a pipeline returns no data
- log dataset sizes in fetch workflow for easier debugging

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck`
- `npm run fetch:u5` *(fails: tsx not installed; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b88eaf808320a5cd84aea98dbcad