### PR TITLE
fix(u5): robust WDI fetch (status logs, ISO fallback, pop guard, year intersection)

### DIFF
--- a/scripts/pipelines/u5_mortality.ts
+++ b/scripts/pipelines/u5_mortality.ts
@@ -1,10 +1,29 @@
-import { writeJson } from '../lib/io.ts';
-import { upsertSource } from '../lib/manifest.ts';
+import { writeJson } from "../lib/io.ts";
+import { upsertSource } from "../lib/manifest.ts";
 
-const INDICATOR = 'SH.DYN.MORT';
-const POP = 'SP.POP.TOTL';
+const INDICATOR = "SH.DYN.MORT";
+const POP = "SP.POP.TOTL";
 const EXCLUDE = new Set([
-  'WLD','HIC','INX','LIC','LMC','MIC','UMC','OED','ARB','EAP','ECA','ECS','EUU','LCN','LAC','MEA','NAC','SAS','SSA','FCS'
+  "WLD",
+  "HIC",
+  "INX",
+  "LIC",
+  "LMC",
+  "MIC",
+  "UMC",
+  "OED",
+  "ARB",
+  "EAP",
+  "ECA",
+  "ECS",
+  "EUU",
+  "LCN",
+  "LAC",
+  "MEA",
+  "NAC",
+  "SAS",
+  "SSA",
+  "FCS",
 ]);
 
 function isIso3(code: string): boolean {
@@ -13,15 +32,45 @@ function isIso3(code: string): boolean {
 
 async function fetchWdiAll(ind: string) {
   const base =
-    'https://api.worldbank.org/v2/country/all/indicator/' +
+    "https://api.worldbank.org/v2/country/all/indicator/" +
     ind +
-    '?format=json&per_page=20000';
-  const first = await (await fetch(base + '&page=1')).json();
-  const pages = (Array.isArray(first) && (first[0] as any)?.pages) || 1;
-  const rows = Array.isArray(first) && Array.isArray(first[1]) ? [...first[1]] : [];
+    "?format=json&per_page=20000";
+  const res1 = await fetch(base + "&page=1", {
+    headers: { "User-Agent": "GAI-fetch-bot" },
+  });
+  if (!res1.ok) {
+    const txt = await res1.text().catch(() => "");
+    console.error(
+      `[u5] WDI first page ${ind} HTTP ${res1.status} ${res1.statusText} :: ${txt.slice(
+        0,
+        200,
+      )}`,
+    );
+    throw new Error(`u5: WDI ${ind} first page not OK`);
+  }
+  const first = await res1.json();
+  if (!Array.isArray(first) || !Array.isArray(first[1])) {
+    console.error(
+      "[u5] Unexpected WDI payload (first page)",
+      JSON.stringify(first).slice(0, 500),
+    );
+    return [];
+  }
+  const pages = (first[0] as any)?.pages || 1;
+  const rows = [...first[1]];
   for (let p = 2; p <= pages; p++) {
-    const part = await (await fetch(base + '&page=' + p)).json();
-    if (Array.isArray(part) && Array.isArray(part[1])) rows.push(...part[1]);
+    const rsp = await fetch(base + "&page=" + p, {
+      headers: { "User-Agent": "GAI-fetch-bot" },
+    });
+    if (!rsp.ok) {
+      const t = await rsp.text().catch(() => "");
+      console.error(
+        `[u5] WDI page ${p} ${ind} HTTP ${rsp.status} ${rsp.statusText} :: ${t.slice(0, 200)}`,
+      );
+      break;
+    }
+    const seg = await rsp.json();
+    if (Array.isArray(seg) && Array.isArray(seg[1])) rows.push(...seg[1]);
   }
   return rows;
 }
@@ -31,34 +80,40 @@ export async function run() {
     fetchWdiAll(INDICATOR),
     fetchWdiAll(POP),
   ]);
-  console.log('[u5] raw U5MR rows:', mortRows.length);
-  console.log('[u5] raw POP rows:', popRows.length);
+  console.log("[u5] raw U5MR rows:", mortRows.length);
+  console.log("[u5] raw POP rows:", popRows.length);
 
   const mort: Record<string, Record<number, number>> = {};
   for (const d of mortRows) {
-    const iso = d?.countryiso3code;
+    const iso = (d?.countryiso3code || d?.country?.id || "").toUpperCase();
     const year = Number(d?.date);
     const val = Number(d?.value);
     if (!iso || !isIso3(iso) || isNaN(val) || isNaN(year)) continue;
     mort[iso] ??= {};
     mort[iso][year] = val;
   }
-  console.log('[u5] ISO3 with U5MR:', Object.keys(mort).length);
+  console.log("[u5] ISO3 with U5MR:", Object.keys(mort).length);
 
   const pop: Record<string, Record<number, number>> = {};
   for (const d of popRows) {
-    const iso = d?.countryiso3code;
+    const iso = (d?.countryiso3code || d?.country?.id || "").toUpperCase();
     const year = Number(d?.date);
     const val = Number(d?.value);
     if (!iso || !isIso3(iso) || isNaN(val) || isNaN(year)) continue;
     pop[iso] ??= {};
     pop[iso][year] = val;
   }
-  console.log('[u5] ISO3 with POP:', Object.keys(pop).length);
+  console.log("[u5] ISO3 with POP:", Object.keys(pop).length);
+  if (!Object.keys(pop).length) throw new Error("u5: population fetch empty");
 
   const years = new Set<number>();
-  for (const iso in mort) for (const y in mort[iso]) years.add(Number(y));
-  console.log('[u5] years count:', years.size);
+  for (const iso in mort) {
+    for (const y in mort[iso]) {
+      const yy = Number(y);
+      if (pop[iso]?.[yy] != null) years.add(yy);
+    }
+  }
+  console.log("[u5] years count:", years.size);
 
   const data = Array.from(years)
     .map((year) => {
@@ -78,25 +133,29 @@ export async function run() {
       return undefined;
     })
     .filter(Boolean)
-    .sort((a: any, b: any) => a.year - b.year) as { year: number; value: number }[];
-  console.log('[u5] computed points:', data.length);
+    .sort((a: any, b: any) => a.year - b.year) as {
+    year: number;
+    value: number;
+  }[];
+  console.log("[u5] computed points:", data.length);
   if (!Array.isArray(data) || data.length === 0) {
-    throw new Error('u5_mortality: no data fetched — skipping write');
+    throw new Error("u5_mortality: no data fetched — skipping write");
   }
 
-  await writeJson('public/data/u5_mortality.json', data);
-  await upsertSource('u5_mortality', {
-    name: 'Under-5 mortality',
-    domain: 'Health & Wellbeing',
-    unit: 'per 1,000 live births',
-    source_org: 'UN IGME via World Bank WDI',
-    source_url: 'https://data.worldbank.org/indicator/SH.DYN.MORT',
-    license: 'CC BY 4.0',
-    cadence: 'annual',
+  await writeJson("public/data/u5_mortality.json", data);
+  await upsertSource("u5_mortality", {
+    name: "Under-5 mortality",
+    domain: "Health & Wellbeing",
+    unit: "per 1,000 live births",
+    source_org: "UN IGME via World Bank WDI",
+    source_url: "https://data.worldbank.org/indicator/SH.DYN.MORT",
+    license: "CC BY 4.0",
+    cadence: "annual",
     method:
-      'Population-weighted global mean of national SH.DYN.MORT using SP.POP.TOTL; exclude aggregates; round 2 decimals.',
+      "Population-weighted global mean of national SH.DYN.MORT using SP.POP.TOTL; exclude aggregates; round 2 decimals.",
     updated_at: new Date().toISOString().slice(0, 10),
-    data_start_year: Array.isArray(data) && data.length ? data[0].year : undefined,
+    data_start_year:
+      Array.isArray(data) && data.length ? data[0].year : undefined,
   });
   return data;
 }


### PR DESCRIPTION
## Summary
- log HTTP status and partial body for WDI errors
- accept ISO codes from `country.id`
- guard against missing population data and intersect years

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint setup)*
- `npm run typecheck`
- `npx tsx scripts/pipelines/u5_mortality.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bec58ef88320bdb83f98f59ef7a1
------

What
- Log HTTP status/body when WDI replies are non-OK or unexpected.
- Accept ISO codes from `countryiso3code` or `country.id`, still excluding aggregates.
- Guard when population fetch is empty.
- Intersect mortality/population years before computing.
- Keep verbose logs and empty-dataset guard.

Why
- Diagnostics showed WDI errors could be silently treated as empty arrays.
- ISO codes can appear as `country.id`; filtering them out yields zero data.
- Prevent false-success and provide actionable logs.

Acceptance
- CI green (typecheck/build + validators).
- After merge: Actions → Fetch Data → Run workflow (branch main):
  - In “Run npm run fetch:all” step, you should see:
    [u5] raw U5MR rows: N
    [u5] raw POP rows: M
    [u5] ISO3 with U5MR: X
    [u5] ISO3 with POP: Y
    [u5] years count: Z
    [u5] computed points: K
  - If WDI is non-OK, logs show HTTP status/body; job fails early.
  - If successful and files changed, an auto PR appears with updated /public/data/**.