### PR TITLE
data(extreme_poverty): add WDI pipeline

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-08-31
+- data(extreme_poverty): add WDI pipeline (SI.POV.DDAY); pop-weighted global; registry/docs updated.
+
 ## 2025-08-30
 - build(alignment): add metrics registry, relative helper, dataset schema validation, and scheduler scaffold.
 

--- a/docs/METHODS.md
+++ b/docs/METHODS.md
@@ -22,3 +22,9 @@
 - Unit: years
 - Cadence: annual
 - Method: use WB annual values; include only numeric values; round 2 decimals.
+
+**Extreme poverty (% at $2.15) — Global (World Bank)**
+- Source: World Bank API (SI.POV.DDAY)
+- Unit: % of population
+- Cadence: annual
+- Method: Pop-weighted global mean from national SI.POV.DDAY using SP.POP.TOTL; exclude aggregates; round to 2 decimals; WDI may include modeled/nowcasted values.

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -13,4 +13,5 @@ export const METRICS: Metric[] = [
   { id: 'co2_ppm', name: 'CO₂ concentration', domain: 'Climate & Environment', unit: 'ppm', direction: 'down_is_better', source: 'NOAA/ESRL' },
   { id: 'life_expectancy', name: 'Life expectancy', domain: 'Health & Wellbeing', unit: 'years', direction: 'up_is_better', source: 'WHO/World Bank' },
   { id: 'internet_use', name: 'Individuals using the internet', domain: 'Education & Digital', unit: '%', direction: 'up_is_better', source: 'ITU' },
+  { id: 'extreme_poverty', name: 'Extreme poverty ($2.15)', domain: 'Economics & Poverty', unit: '%', direction: 'down_is_better', source: 'World Bank' },
 ]

--- a/public/data/metrics_registry.json
+++ b/public/data/metrics_registry.json
@@ -24,5 +24,18 @@
     "cadence": "annual",
     "source_url": "https://data.worldbank.org/indicator/SP.DYN.LE00.IN",
     "notes": "World Bank life expectancy at birth"
+  },
+  {
+    "id": "extreme_poverty",
+    "domain": "Economics & Poverty",
+    "unit": "%",
+    "alignment_or_capability": "alignment",
+    "direction": "down",
+    "reference_min": 0,
+    "reference_max": 80,
+    "target": 0,
+    "cadence": "annual",
+    "source_url": "https://data.worldbank.org/indicator/SI.POV.DDAY",
+    "notes": "Pop-weighted global mean from national SI.POV.DDAY; excludes aggregates; round to 2 decimals; WDI may include modeled/nowcasted values."
   }
 ]

--- a/public/data/sources.json
+++ b/public/data/sources.json
@@ -29,5 +29,17 @@
     "method": "Annual mean of monthly averages, exclude -99.99; round to 2 decimals.",
     "updated_at": "2025-08-27",
     "data_start_year": 2000
+  },
+  "extreme_poverty": {
+    "name": "Extreme poverty ($2.15)",
+    "domain": "Economics & Poverty",
+    "unit": "% of population",
+    "source_org": "World Bank WDI",
+    "source_url": "https://data.worldbank.org/indicator/SI.POV.DDAY",
+    "license": "CC BY 4.0",
+    "cadence": "annual",
+    "method": "Pop-weighted global mean from SI.POV.DDAY using SP.POP.TOTL; exclude aggregates; round to 2 decimals; WDI may include modeled/nowcasted values.",
+    "updated_at": "2025-08-29T09:29:32.290Z",
+    "data_start_year": 1981
   }
 }

--- a/scripts/fetch-all.ts
+++ b/scripts/fetch-all.ts
@@ -1,10 +1,12 @@
 import { run as co2 } from './pipelines/co2.ts';
 import { run as life_expectancy } from './pipelines/life_expectancy.ts';
+import { run as extreme_poverty } from './pipelines/extreme_poverty.ts';
 
 export async function runAll() {
   const pipelines = [
     { name: 'co2_ppm', run: co2 },
     { name: 'life_expectancy', run: life_expectancy },
+    { name: 'extreme_poverty', run: extreme_poverty },
   ];
   for (const p of pipelines) {
     console.log(`start ${p.name}`);

--- a/scripts/pipelines/extreme_poverty.ts
+++ b/scripts/pipelines/extreme_poverty.ts
@@ -1,0 +1,94 @@
+import { writeJson } from '../lib/io.ts';
+import { upsertSource } from '../lib/manifest.ts';
+
+const EXCLUDE = new Set([
+  'WLD','HIC','INX','LIC','LMC','MIC','UMC','OED','ARB','EAP','ECA','ECS','EUU','LCN','LAC','MEA','NAC','SAS','SSA','FCS'
+]);
+
+async function fetchIndicator(indicator: string) {
+  const rows: any[] = [];
+  let page = 1;
+  while (true) {
+    const url = `https://api.worldbank.org/v2/country/all/indicator/${indicator}?format=json&per_page=20000&page=${page}`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      const txt = await res.text();
+      console.error(`[extreme_poverty] fetch ${indicator} page ${page} failed: ${res.status} ${txt.slice(0,100)}`);
+      throw new Error('fetch failed');
+    }
+    const json = await res.json();
+    const meta = Array.isArray(json) ? json[0] : null;
+    const data = Array.isArray(json) ? json[1] : null;
+    if (Array.isArray(data)) rows.push(...data);
+    const pages = meta?.pages ?? 1;
+    if (page >= pages) break;
+    page++;
+  }
+  return rows;
+}
+
+export async function run() {
+  const [povRows, popRows] = await Promise.all([
+    fetchIndicator('SI.POV.DDAY'),
+    fetchIndicator('SP.POP.TOTL')
+  ]);
+
+  const popMap = new Map<string, number>();
+  for (const d of popRows) {
+    const iso = (d?.countryiso3code || d?.country?.id || '').toUpperCase();
+    const year = Number(d?.date);
+    const val = Number(d?.value);
+    if (iso && !EXCLUDE.has(iso) && /^[A-Z]{3}$/.test(iso) && !isNaN(year) && !isNaN(val)) {
+      popMap.set(`${iso}:${year}`, val);
+    }
+  }
+  if (popMap.size === 0) throw new Error('[extreme_poverty] empty population map');
+
+  const totals: Record<number, { sum: number; pop: number }> = {};
+  const isoSet = new Set<string>();
+  for (const d of povRows) {
+    const iso = (d?.countryiso3code || d?.country?.id || '').toUpperCase();
+    const year = Number(d?.date);
+    const pov = Number(d?.value);
+    if (iso && !EXCLUDE.has(iso) && /^[A-Z]{3}$/.test(iso) && !isNaN(year) && !isNaN(pov)) {
+      const pop = popMap.get(`${iso}:${year}`);
+      if (pop != null && !isNaN(pop)) {
+        if (!totals[year]) totals[year] = { sum: 0, pop: 0 };
+        totals[year].sum += pov * pop;
+        totals[year].pop += pop;
+        isoSet.add(iso);
+      }
+    }
+  }
+
+  const data = Object.entries(totals)
+    .map(([year, { sum, pop }]) => ({ year: Number(year), value: Number((sum / pop).toFixed(2)) }))
+    .sort((a, b) => a.year - b.year);
+  if (data.length === 0) {
+    throw new Error('[extreme_poverty] computed points = 0; nothing written.');
+  }
+
+  console.log(`[extreme_poverty] raw rows: ${povRows.length} / pop rows: ${popRows.length} / ISO3 count: ${isoSet.size} / years count: ${Object.keys(totals).length} / computed points: ${data.length}`);
+
+  await writeJson('public/data/extreme_poverty.json', data);
+  await upsertSource('extreme_poverty', {
+    name: 'Extreme poverty ($2.15)',
+    domain: 'Economics & Poverty',
+    unit: '% of population',
+    source_org: 'World Bank WDI',
+    source_url: 'https://data.worldbank.org/indicator/SI.POV.DDAY',
+    license: 'CC BY 4.0',
+    cadence: 'annual',
+    method: 'Pop-weighted global mean from SI.POV.DDAY using SP.POP.TOTL; exclude aggregates; round to 2 decimals; WDI may include modeled/nowcasted values.',
+    updated_at: new Date().toISOString(),
+    data_start_year: data.length ? data[0].year : undefined,
+  });
+  return data;
+}
+
+if ((import.meta as any).main) {
+  run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- refine World Bank extreme poverty pipeline with pagination, ISO3 fallback, aggregate exclusion, and pop-weighted mean rounded to 2 decimals
- document and register metric with notes on aggregate exclusion and potential modeled/nowcasted values
- add guard against zero computed points and log population row counts; dataset populated by workflow

## Testing
- `npm run typecheck` *(fails: missing Next/React modules; attempted ‘npm ci’ but network stalled)*
- `node scripts/validate-datasets.js`
- `npm run validate:sources`


------
https://chatgpt.com/codex/tasks/task_e_68b0a85185d08320b2c29ed8031669e5