### PR TITLE
chore(registry): restore internet_use metric entry

### DIFF
--- a/public/data/metrics_registry.json
+++ b/public/data/metrics_registry.json
@@ -26,6 +26,19 @@
     "notes": "World Bank life expectancy at birth"
   },
   {
+    "id": "internet_use",
+    "domain": "Education & Digital",
+    "unit": "%",
+    "alignment_or_capability": "alignment",
+    "direction": "up",
+    "reference_min": 0,
+    "reference_max": 100,
+    "target": null,
+    "cadence": "annual",
+    "source_url": "https://data.worldbank.org/indicator/IT.NET.USER.ZS",
+    "notes": "Individuals using the Internet (% of population); round to 2 decimals."
+  },
+  {
     "id": "u5_mortality",
     "domain": "Health & Wellbeing",
     "unit": "per 1,000",


### PR DESCRIPTION
## Summary
- restore `internet_use` entry in metrics registry and classify as alignment
- normalize notes to mention rounding to 2 decimals

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: multiple missing module/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8a989f08320805afdd71b30ed0a
------

What
- Re-add the internet_use metric to public/data/metrics_registry.json with alignment classification, bounds, cadence, source, and notes ("round to 2 decimals.").

Why
- The entry was missing; restoring parity with main expectations and the UI.

Acceptance
- CI green; no runtime changes expected.