### PR TITLE
Hide internet use metric card from MVP dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,9 @@ import { METRICS } from '@/lib/metrics'
 import { computeRelative } from '@/lib/relative'
 import SourcesFooter from '@/components/SourcesFooter'
 
-const DISPLAY_METRICS = METRICS.filter(m => m.id !== 'internet_use')
+// Temporarily hide metrics that are not part of the MVP dashboard view.
+const HIDDEN_METRIC_IDS = new Set(['internet_use'])
+const DISPLAY_METRICS = METRICS.filter(m => !HIDDEN_METRIC_IDS.has(m.id))
 
 type Pt = { year: number; value: number }
 const fetchVersion = process.env.NEXT_PUBLIC_COMMIT_SHA ?? Date.now().toString()


### PR DESCRIPTION
## What
- add a hidden metric list so the `internet_use` chart is excluded from the MVP dashboard render while keeping supporting code in place for later phases

## Why
- the "Individuals using the internet" chart is out of scope for the MVP and should not appear in the UI right now

## Acceptance
- the dashboard no longer renders the "Individuals using the internet" line chart
- supporting helpers remain unchanged so the metric can be re-enabled in a later phase

## Verification
- `npm run lint` *(fails in the sandbox because the TypeScript dev dependencies are not installed; expect CI to handle the install)*

------
https://chatgpt.com/codex/tasks/task_e_68e5323f279c83208d2e4ae1bb317044